### PR TITLE
Fix name of variable font families in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Letters on a grid is how we see our code. Why not make those letters better?
 Monaspace is made available as both a variable-axis font and as static builds. You can install them both side-by-side; their family names are distinct. For example:
 
 - `Monaspace _____`: the static family
-- `Monaspace _____ VF`: the variable family
+- `Monaspace _____ Var`: the variable family
 
 The variable fonts have one file per family (Neon, Argon, etc). Modern and convenient!
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Letters on a grid is how we see our code. Why not make those letters better?
 Monaspace is made available as both a variable-axis font and as static builds. You can install them both side-by-side; their family names are distinct. For example:
 
 - `Monaspace _____`: the static family
-- `Monaspace _____ Var`: the variable family
+- `Monaspace _____ Var` or `VF`: the variable family
 
 The variable fonts have one file per family (Neon, Argon, etc). Modern and convenient!
 


### PR DESCRIPTION
The README currently says the variable font family names end in `VF`, but it seems like they actually end in `Var`