### PR TITLE
Add documentation block for using homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ There is also a script which automates the deletion of all Monaspace fonts from 
 $ bash ./util/install_macos.sh
 ```
 
+You can also use [homebrew](https://brew.sh/) as an alternative:
+
+```bash
+brew install --cask font-monaspace
+```
+
 ### Webfonts
 
 All files with a `.woff` or `.woff2` suffix are intended for use on the web. You do not install them with your operating system, but rather add them to your web development project.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can also use [homebrew](https://brew.sh/) as an alternative:
 
 ```bash
 brew tap homebrew/cask-fonts
-brew install --cask font-monaspace
+brew install font-monaspace
 ```
 
 ### Webfonts

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $ bash ./util/install_macos.sh
 You can also use [homebrew](https://brew.sh/) as an alternative:
 
 ```bash
+brew tap homebrew/cask-fonts
 brew install --cask font-monaspace
 ```
 


### PR DESCRIPTION
Add a documentation block for installing the font via [homebrew](https://brew.sh/) on a MacOS.

Addition to and closes #14 