### PR TITLE
readme: correct linux installation relative path and use executable f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ You can manually drag the fonts from the `fonts/otf` and `fonts/variable` direct
 There is also a script which automates the deletion of all Monaspace fonts from `~/.local/share/fonts` and then copies over the latest versions. Invoke it from the root of the repo like:
 
 ```bash
-$ cd util
-$ bash ./install_linux.sh
+$ ./util/install_linux.sh
 ```
 
 ### Webfonts


### PR DESCRIPTION
…ormat

The `install_linux.sh` script uses relative paths:
``` bash
# copy all fonts from ./otf to ~/.local/share/fonts
cp ./fonts/otf/* ~/.local/share/fonts

# copy variable fonts from ./variable to ~/.local/share/fonts
cp ./fonts/variable/* ~/.local/share/fonts
```
And should be run from the project root. Running inside the `util` directory will break relative paths.

Also, the `install_linux.sh` file has *executable* mod, which allows it to run directly.

