### PR TITLE
Fix usage of `install_macos.sh` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ You can manually drag the fonts from the `fonts/otf` or `fonts/variable` directo
 There is also a script that automates the deletion of all Monaspace fonts from `~/Library/Fonts` and then copies over the latest versions. Invoke it from the root of the repo like:
 
 ```bash
-$ cd util
-$ bash ./install_macos.sh
+$ bash ./util/install_macos.sh
 ```
 You can also use [homebrew](https://brew.sh/) as an alternative:
 


### PR DESCRIPTION
The provided suggestion to run `./install_macos.sh` from the `util`
directory fails since the script expects to be relative to the
root of the content.

```
❯ cd util
❯ bash ./install_macos.sh
cp: ./fonts/otf/*: No such file or directory
cp: ./fonts/variable/*: No such file or directory
```

Avoiding the change to `util` and running `bash ./util/install_macos.sh`
works.

A similar pull request exists for the Linux installation instructions at #104