### PR TITLE
Add windows install script ( PowerShell )

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can manually drag the fonts from the `fonts/otf` or `fonts/variable` directo
 
 ```powershell
 $ cd util
-$ ./install_windows.sh
+$ ./install_windows.cmd
 ```
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ brew install font-monaspace
 ### Windows
 You can manually drag the fonts from the `fonts/otf` or `fonts/variable` directory into `C:\Windows\Fonts`. Alternatively, right-click the fonts you want and click Install.
 
+```powershell
+$ cd util
+$ ./install_windows.sh
+```
+
 ### Linux
 You can manually drag the fonts from the `fonts/otf` and `fonts/variable` directory into `~/.local/share/fonts`.
 

--- a/util/install_windows.cmd
+++ b/util/install_windows.cmd
@@ -1,0 +1,19 @@
+@echo off
+
+echo Installing fonts...
+
+set mainFontFolder="./../fonts/otf"
+
+for /r "%mainFontFolder%" %%f in (*.ttf, *.otf, *.woff, *.woff2) do (
+  copy "%%f" "%WINDIR%\Fonts"
+  reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" /v "%%~nxf (TrueType)" /t REG_SZ /d %%~nxf /f
+)
+
+set mainFontFolder="./../fonts/varible"
+
+for /r "%mainFontFolder%" %%f in (*.ttf, *.otf, *.woff, *.woff2) do (
+  copy "%%f" "%WINDIR%\Fonts"
+  reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" /v "%%~nxf (TrueType)" /t REG_SZ /d %%~nxf /f
+)
+
+echo All fonts installed successfully.

--- a/util/install_windows.cmd
+++ b/util/install_windows.cmd
@@ -1,5 +1,14 @@
 @echo off
 
+echo Checking for admin rights...
+net session >nul 2>&1
+if %errorLevel% == 0 (
+  echo Admin rights granted.
+) else (
+  echo Admin rights required. Please run this script as an administrator.
+  exit /b 1
+)
+
 echo Installing fonts...
 
 set mainFontFolder="./../fonts/otf"


### PR DESCRIPTION
:: This script installs fonts on Windows by copying them to the Fonts folder and adding registry entries for them.

- check Admin rights
- copy `fonts/otf` & `fonts/varible` to `$CurrentVersion\Fonts`
- add each fonts to registry

