### PR TITLE
corrected installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ You can manually drag the fonts from the `fonts/otf` or `fonts/variable` directo
 There is also a script that automates the deletion of all Monaspace fonts from `~/Library/Fonts` and then copies over the latest versions. Invoke it from the root of the repo like:
 
 ```bash
-$ cd util
-$ bash ./install_macos.sh
+$ bash ./util/install_macos.sh
 ```
 You can also use [homebrew](https://brew.sh/) as an alternative:
 


### PR DESCRIPTION
corrected the example run. Otherwise below error would occur.

```bash
❯ cd util
❯ bash ./install_macos.sh
cp: ./fonts/otf/*: No such file or directory
cp: ./fonts/variable/*: No such file or directory
```