### PR TITLE
Fixes install_linux.sh in the case that ~/.local/share/fonts doesn't exist

### DIFF
--- a/util/install_linux.sh
+++ b/util/install_linux.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# ensure that ~/.local/share/fonts exists
+mkdir -p ~/.local/share/fonts
+
 # remove all fonts from ~/.local/share/fonts that start with "Monaspace"
 rm -rf ~/.local/share/fonts/Monaspace*
 


### PR DESCRIPTION
The Linux install script didn't work for me because Pop!_OS 22.04 doesn't create the `~/.local/share/fonts` directory by default, and the script requires that it exists.