### PR TITLE
Update install_linux.sh cp: cannot `stat' on './fonts/otf/*': No such file or directory

### DIFF
--- a/util/install_linux.sh
+++ b/util/install_linux.sh
@@ -4,10 +4,10 @@
 rm -rf ~/.local/share/fonts/Monaspace*
 
 # copy all fonts from ./otf to ~/.local/share/fonts
-cp ./fonts/otf/* ~/.local/share/fonts
+cp ../fonts/otf/* ~/.local/share/fonts
 
 # copy variable fonts from ./variable to ~/.local/share/fonts
-cp ./fonts/variable/* ~/.local/share/fonts
+cp ../fonts/variable/* ~/.local/share/fonts
 
 # Build font information caches
 fc-cache -f


### PR DESCRIPTION
## cp: cannot `stat' ... No such file or directory

I have detected that I cannot execute the script, therefore, I did so many tests, deleting folders and creating again, the error was that the font folder could not be found and I added one more point to indicate that it goes back and looks for the fonts folder.


