### PR TITLE
Fix install_linux.sh paths

### DIFF
--- a/util/install_linux.sh
+++ b/util/install_linux.sh
@@ -4,10 +4,10 @@
 rm -rf ~/.local/share/fonts/Monaspace*
 
 # copy all fonts from ./otf to ~/.local/share/fonts
-cp ./fonts/otf/* ~/.local/share/fonts
+cp ../fonts/otf/* ~/.local/share/fonts
 
 # copy variable fonts from ./variable to ~/.local/share/fonts
-cp ./fonts/variable/* ~/.local/share/fonts
+cp ../fonts/variable/* ~/.local/share/fonts
 
 # Build font information caches
 fc-cache -f


### PR DESCRIPTION
Otherwise the instuctions of:
```
$ cd util
$ bash ./install_linux.sh
```
will lead to copying path errors:
```
cp: cannot stat './fonts/otf/*': No such file or directory
cp: cannot stat './fonts/variable/*': No such file or directory
```