### PR TITLE
docs(README): fix linux install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ You can manually drag the fonts from the `fonts/otf` and `fonts/variable` direct
 There is also a script which automates the deletion of all Monaspace fonts from `~/.local/share/fonts` and then copies over the latest versions. Invoke it from the root of the repo like:
 
 ```bash
-$ cd util
-$ bash ./install_linux.sh
+$ bash ./util/install_linux.sh
 ```
 
 ### Webfonts


### PR DESCRIPTION
The script expects the cwd to be the root of the repo, the existing instructions that say to first change directory to `util` therefore fail.

Changes the instructions to run the script from project root, and installation succeeds.