### PR TITLE
Allow Linux install script to be run from anywhere

### DIFF
--- a/util/install_linux.sh
+++ b/util/install_linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+UTIL_DIR="$(dirname $0)"
 
 # ensure that ~/.local/share/fonts exists
 mkdir -p ~/.local/share/fonts
@@ -7,6 +8,8 @@ mkdir -p ~/.local/share/fonts
 rm -rf ~/.local/share/fonts/Monaspace*
 
 mkdir -p ~/.local/share/fonts/Monaspace/
+
+cd "$UTIL_DIR/.."
 
 # copy all fonts from ./otf to ~/.local/share/fonts
 cp ./fonts/otf/* ~/.local/share/fonts/Monaspace/


### PR DESCRIPTION
I at least don't see a reason to *not* do this, unless I'm missing something :thinking:
Instead of requiring the user to be in the `monaspace` directory, this would allow them to, for example, run `./Downloads/monaspace/util/install_linux.sh`.

This change could most likely be applied to `install_macos.sh`, too, but I didn't want to apply that since I'm not a MacOS user and am unable to do a quick test.

Love this font, BTW :heart:


---

Edit: Oof, looking at the old PRs, I see there's a lot of activity regarding installation. I hope I'm not duplicating anything.