### PR TITLE
Update Homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ $ bash util/install_macos.sh
 You can also use [homebrew](https://brew.sh/) as an alternative:
 
 ```bash
-brew tap homebrew/cask-fonts
-brew install font-monaspace
+$ brew install --cask font-monaspace
 ```
 
 ### Windows


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask-fonts was deprecated and `font-monaspace` was migrated to `homebrew/cask`.

Fixes https://github.com/githubnext/monaspace/issues/225