### PR TITLE
Fixed install_linux.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Added change log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-Added change log

--- a/util/install_linux.sh
+++ b/util/install_linux.sh
@@ -1,41 +1,28 @@
 #!/bin/bash
 
-set -e  # Exit immediately if a command exits with a non-zero status
-set -u  # Treat unset variables as an error and exit immediately
-set -o pipefail  # Return the exit status of the last command in the pipeline that failed
+# Set the current user
+USER=$(logname)
+echo "Current user is $USER"
 
-echo "Starting font installation script..."
+# Set the target font directory
+TARGET_DIR="/home/$USER/.local/share/fonts/Monaspace"
 
-# Ensure that ~/.local/share/fonts exists
-echo "Creating directory: ~/.local/share/fonts"
-mkdir -p ~/.local/share/fonts
+# Create the ~/.local/share/fonts/ directory if it doesn't exist
+mkdir -p "/home/$USER/.local/share/fonts"
 
-# Remove all fonts from ~/.local/share/fonts that start with "Monaspace"
-echo "Removing existing Monaspace fonts from ~/.local/share/fonts"
-rm -rf ~/.local/share/fonts/Monaspace*
-
-# Recreate the Monaspace directory
-echo "Creating directory: ~/.local/share/fonts/Monaspace/"
-mkdir -p ~/.local/share/fonts/Monaspace/
-
-# Copy all fonts from ./otf to ~/.local/share/fonts/Monaspace/
-if [ -d "./fonts/otf" ]; then
-    echo "Copying fonts from ./fonts/otf/ to ~/.local/share/fonts/Monaspace/"
-    cp -v ./fonts/otf/* ~/.local/share/fonts/Monaspace/ || echo "No files to copy from ./fonts/otf"
-else
-    echo "Directory ./fonts/otf does not exist"
+# Remove the Monaspace directory if it exists
+if [ -d "$TARGET_DIR" ]; then
+  rm -rf "$TARGET_DIR"
 fi
 
-# Copy variable fonts from ./variable to ~/.local/share/fonts/Monaspace/
-if [ -d "./fonts/variable" ]; then
-    echo "Copying fonts from ./fonts/variable/ to ~/.local/share/fonts/Monaspace/"
-    cp -v ./fonts/variable/* ~/.local/share/fonts/Monaspace/ || echo "No files to copy from ./fonts/variable"
-else
-    echo "Directory ./fonts/variable does not exist"
-fi
+# Create the Monaspace directory
+mkdir -p "$TARGET_DIR"
 
-# Build font information caches
-echo "Rebuilding font information caches with fc-cache -f"
-fc-cache -f
+# Copy fonts from the local repository to the target directory
+cp -r ./fonts/otf/* "$TARGET_DIR/"
+cp -r ./fonts/variable/* "$TARGET_DIR/"
 
-echo "Font installation completed successfully."
+# Update the font cache
+fc-cache -fv
+
+echo "Fonts copied to $TARGET_DIR and font cache updated."

--- a/util/install_linux.sh
+++ b/util/install_linux.sh
@@ -1,18 +1,41 @@
 #!/bin/bash
 
-# ensure that ~/.local/share/fonts exists
+set -e  # Exit immediately if a command exits with a non-zero status
+set -u  # Treat unset variables as an error and exit immediately
+set -o pipefail  # Return the exit status of the last command in the pipeline that failed
+
+echo "Starting font installation script..."
+
+# Ensure that ~/.local/share/fonts exists
+echo "Creating directory: ~/.local/share/fonts"
 mkdir -p ~/.local/share/fonts
 
-# remove all fonts from ~/.local/share/fonts that start with "Monaspace"
+# Remove all fonts from ~/.local/share/fonts that start with "Monaspace"
+echo "Removing existing Monaspace fonts from ~/.local/share/fonts"
 rm -rf ~/.local/share/fonts/Monaspace*
 
+# Recreate the Monaspace directory
+echo "Creating directory: ~/.local/share/fonts/Monaspace/"
 mkdir -p ~/.local/share/fonts/Monaspace/
 
-# copy all fonts from ./otf to ~/.local/share/fonts
-cp ./fonts/otf/* ~/.local/share/fonts/Monaspace/
+# Copy all fonts from ./otf to ~/.local/share/fonts/Monaspace/
+if [ -d "./fonts/otf" ]; then
+    echo "Copying fonts from ./fonts/otf/ to ~/.local/share/fonts/Monaspace/"
+    cp -v ./fonts/otf/* ~/.local/share/fonts/Monaspace/ || echo "No files to copy from ./fonts/otf"
+else
+    echo "Directory ./fonts/otf does not exist"
+fi
 
-# copy variable fonts from ./variable to ~/.local/share/fonts
-cp ./fonts/variable/* ~/.local/share/fonts/Monaspace/
+# Copy variable fonts from ./variable to ~/.local/share/fonts/Monaspace/
+if [ -d "./fonts/variable" ]; then
+    echo "Copying fonts from ./fonts/variable/ to ~/.local/share/fonts/Monaspace/"
+    cp -v ./fonts/variable/* ~/.local/share/fonts/Monaspace/ || echo "No files to copy from ./fonts/variable"
+else
+    echo "Directory ./fonts/variable does not exist"
+fi
 
 # Build font information caches
+echo "Rebuilding font information caches with fc-cache -f"
 fc-cache -f
+
+echo "Font installation completed successfully."


### PR DESCRIPTION
Thought I submitted this last night, whatever: 

Bash 5.2, [Ubuntu 24.04](https://releases.ubuntu.com/noble)

Input from root of  ```~/Workspaces/monaspace```

Input:

> ```sudo bash /util/install_linux.sh```

Also tried:

> ```chmod -X install_linux.sh```

Though sudo should have overwritten that.

Output (original line 12 & 15, directories created manually and also tried to let the script do its thing made no difference.

Output:

> ```cp: cannot stat {{directory_name}}*': No such file or directory```

Edit: I believe context on the terminal is correct, as non root "geoffrey" ... it does some weird things when starting over with original script and deleting ```/home/geoffrey/share/fonts/```

Input:
>```rm -rf ~/local/share/fonts````
>```geoffrey@dell:~$ [ -d "/home/geoffrey/.local/share/fonts/" ] && echo "dir exists" || echo "dir does not exist"```

Output:
>```dir does not exist````

Input (original install_linux.sh):
>```cd geoffrey@dell:~/Workspaces/monaspace$ echo ~```

Output:
```/home/geoffrey``

Run command with debug:

```geoffrey@dell:~/Workspaces/monaspace$ sudo bash -x util/install_linux.sh 
[sudo] password for geoffrey: 
+ mkdir -p /root/.local/share/fonts
+ rm -rf '/root/.local/share/fonts/Monaspace*'
+ mkdir -p /root/.local/share/fonts/Monaspace/
+ cp ./fonts/otf/MonaspaceArgon-BoldItalic.otf ``` (ommitting all the fonts)```

It will see me as root, install it into root the root user's ```/root/.local/share/fonrts``` then install the rest into ```/home/geoffrey/fonts```

Which I'm not going to type out anymore exact commands I think it is obvious what is happening. I also didn't know I had Starship installed but that didn't matter. The script needs a major overhaul.  Running my script produces somehow different results (Starship remove/purge just to make sure):

Input/Output:
``` bash
geoffrey@dell:~/Workspaces/github-forks/monaspace$ sudo bash -x util/install_linux.sh 
+ set -e
+ set -u
+ set -o pipefail
+ echo 'Starting font installation script...'
Starting font installation script...
+ echo 'Creating directory: ~/.local/share/fonts'
Creating directory: ~/.local/share/fonts
+ mkdir -p /root/.local/share/fonts
+ echo 'Removing existing Monaspace fonts from ~/.local/share/fonts'
Removing existing Monaspace fonts from ~/.local/share/fonts
+ rm -rf /root/.local/share/fonts/Monaspace
+ echo 'Creating directory: ~/.local/share/fonts/Monaspace/'
Creating directory: ~/.local/share/fonts/Monaspace/
+ mkdir -p /root/.local/share/fonts/Monaspace/
+ '[' -d ./fonts/otf ']'
+ echo 'Copying fonts from ./fonts/otf/ to ~/.local/share/fonts/Monaspace/'
Copying fonts from ./fonts/otf/ to ~/.local/share/fonts/Monaspace/`
```

Take my word for it but it does not install ```/home/geoffrey/fonts``` but it puts it all under root. Coming from Debian/Fedora I don't think this would have happened. It would have kept my username, but I'd be in an admin group so I think my PID would be the same but would run through the wheel group. The differences in the scripts with no changes except conditionals impacting globbing is really strange.

I am going to update this script, then try to run under a cross-compile matrix. I do not know why the differences are happening.
