### PR TITLE
Update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ $ bash util/install_macos.sh
 You can also use [homebrew](https://brew.sh/) as an alternative:
 
 ```bash
-brew tap homebrew/cask-fonts
-brew install font-monaspace
+brew install --cask font-monaspace
 ```
 
 ### Windows


### PR DESCRIPTION
(Feel free to educate me or ignore if I've missed something... I'm still learning the eco system and not sure if there would be a reason to have it the way it was 🙂)

When I installed `font-monaspace` I received this error and warning (things still installed after)

![GB-Screenshot 2024-07-15 at 17 03 12](https://github.com/user-attachments/assets/ddc07401-1424-44bc-8df5-22da8395d337)

but I thought I'd update the command based on what https://formulae.brew.sh/cask/font-monaspace#default shows

![GB-Screenshot 2024-07-15 at 17 04 43](https://github.com/user-attachments/assets/02af2297-d8f0-4b1e-9c09-304edfbdc8ad)

