### PR TITLE
Update README.md to remove `brew tap` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ bash util/install_macos.sh
 You can also use [homebrew](https://brew.sh/) as an alternative:
 
 ```bash
-brew install font-monaspace
+brew install --cask font-monaspace
 ```
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ $ bash util/install_macos.sh
 You can also use [homebrew](https://brew.sh/) as an alternative:
 
 ```bash
-brew tap homebrew/cask-fonts
 brew install font-monaspace
 ```
 


### PR DESCRIPTION
`Error: homebrew/cask-fonts was deprecated. This tap is now empty and all its contents were either deleted or migrated.`

This closes #225 