### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ $ bash util/install_macos.sh
 You can also use [homebrew](https://brew.sh/) as an alternative:
 
 ```bash
-brew tap homebrew/cask-fonts
 brew install font-monaspace
 ```
 


### PR DESCRIPTION
Fixes #225 

[Homebrew](https://brew.sh/) no longer maintains cask-fonts, it is currently empty and deprecated. So, after installing Homebrew, simply run `brew install <font>`.