### PR TITLE
docs: improve appearance of Linux install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can manually drag the fonts from the `fonts/otf` and `fonts/variable` direct
 There is also a script which automates the deletion of all Monaspace fonts from `~/.local/share/fonts` and then copies over the latest versions. Invoke it from the root of the repo like:
 
 ```bash
-$ bash util/install_linux.sh
+util/install_linux.sh
 ```
 
 ### Webfonts


### PR DESCRIPTION
The current version copies the incorrect command when using the code block's copy button, and generally could be confusing.

## Visual Difference

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/fb79ecae-e874-4c1c-94e2-d6ec10b6221c) | ![after](https://github.com/user-attachments/assets/80975ee7-26a1-4953-a095-338f93a770b1) |


## Difference of clipboard contents

| Before | After |
|--------|--------|
| `$ bash util/install_linux.sh` | `util/install_linux.sh` |
