### PR TITLE
Install scripts bash improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can manually drag the fonts from the `fonts/otf` or `fonts/variable` directo
 There is also a script that automates the deletion of all Monaspace fonts from `~/Library/Fonts` and then copies over the latest versions. Invoke it from the root of the repo like:
 
 ```bash
-$ bash util/install_macos.sh
+$ ./util/install_macos.sh
 ```
 You can also use [homebrew](https://brew.sh/) as an alternative:
 
@@ -99,7 +99,7 @@ You can manually drag the fonts from the `fonts/otf` and `fonts/variable` direct
 There is also a script which automates the deletion of all Monaspace fonts from `~/.local/share/fonts` and then copies over the latest versions. Invoke it from the root of the repo like:
 
 ```bash
-$ bash util/install_linux.sh
+$ ./util/install_linux.sh
 ```
 
 ### Webfonts

--- a/util/install_linux.sh
+++ b/util/install_linux.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 origin=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit
 
 # ensure that ~/.local/share/fonts exists

--- a/util/install_linux.sh
+++ b/util/install_linux.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+origin=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit
+
 # ensure that ~/.local/share/fonts exists
 mkdir -p ~/.local/share/fonts
 
@@ -9,10 +11,10 @@ rm -rf ~/.local/share/fonts/Monaspace*
 mkdir -p ~/.local/share/fonts/Monaspace/
 
 # copy all fonts from ./otf to ~/.local/share/fonts
-cp ./fonts/otf/* ~/.local/share/fonts/Monaspace/
+cp "${origin}/../fonts/otf/"* ~/.local/share/fonts/Monaspace/
 
 # copy variable fonts from ./variable to ~/.local/share/fonts
-cp ./fonts/variable/* ~/.local/share/fonts/Monaspace/
+cp "${origin}/../fonts/variable/"* ~/.local/share/fonts/Monaspace/
 
 # Build font information caches
 fc-cache -f

--- a/util/install_linux.sh
+++ b/util/install_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 origin=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit
 

--- a/util/install_linux.sh
+++ b/util/install_linux.sh
@@ -4,19 +4,22 @@ set -euo pipefail
 
 origin=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit
 
+input_dir="${origin}/../fonts"
+fonts_dir="${HOME}/.local/share/fonts"
+
 # ensure that ~/.local/share/fonts exists
-mkdir -p ~/.local/share/fonts
+mkdir -p "${fonts_dir}"
 
 # remove all fonts from ~/.local/share/fonts that start with "Monaspace"
-rm -rf ~/.local/share/fonts/Monaspace*
+rm -rf "${fonts_dir}/"Monaspace*
 
-mkdir -p ~/.local/share/fonts/Monaspace/
+mkdir -p "${fonts_dir}/Monaspace/"
 
 # copy all fonts from ./otf to ~/.local/share/fonts
-cp "${origin}/../fonts/otf/"* ~/.local/share/fonts/Monaspace/
+cp "${input_dir}/otf/"* "${fonts_dir}/Monaspace/"
 
 # copy variable fonts from ./variable to ~/.local/share/fonts
-cp "${origin}/../fonts/variable/"* ~/.local/share/fonts/Monaspace/
+cp "${input_dir}/variable/"* "${fonts_dir}/Monaspace/"
 
 # Build font information caches
 fc-cache -f

--- a/util/install_macos.sh
+++ b/util/install_macos.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 origin=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit
 
 # remove all fonts from ~/Library/Fonts that start with "Monaspace"

--- a/util/install_macos.sh
+++ b/util/install_macos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 origin=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit
 

--- a/util/install_macos.sh
+++ b/util/install_macos.sh
@@ -4,11 +4,14 @@ set -euo pipefail
 
 origin=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit
 
+input_dir="${origin}/../fonts"
+fonts_dir="${HOME}/Library/Fonts"
+
 # remove all fonts from ~/Library/Fonts that start with "Monaspace"
-rm -rf ~/Library/Fonts/Monaspace*
+rm -rf "${fonts_dir}"/Monaspace*
 
 # copy all fonts from ./otf to ~/Library/Fonts
-cp "${origin}/../fonts/otf/"* ~/Library/Fonts
+cp "${input_dir}/otf/"* "${fonts_dir}"
 
 # copy variable fonts from ./variable to ~/Library/Fonts
-cp "${origin}/../fonts/variable/"* ~/Library/Fonts
+cp "${input_dir}/variable/"* "${fonts_dir}"

--- a/util/install_macos.sh
+++ b/util/install_macos.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+origin=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit
+
 # remove all fonts from ~/Library/Fonts that start with "Monaspace"
 rm -rf ~/Library/Fonts/Monaspace*
 
 # copy all fonts from ./otf to ~/Library/Fonts
-cp ./fonts/otf/* ~/Library/Fonts
+cp "${origin}/../fonts/otf/"* ~/Library/Fonts
 
 # copy variable fonts from ./variable to ~/Library/Fonts
-cp ./fonts/variable/* ~/Library/Fonts
+cp "${origin}/../fonts/variable/"* ~/Library/Fonts


### PR DESCRIPTION
Original motivation was to let me call the `util/install_macos.sh` script from anywhere, which was my original intent to install the fonts.
I downloaded and extracted the zip somewhere, then from the working dir I was in, I just called `~/Downloads/monaspace-v1.101/util/install_macos.sh` and it failed.

With the first commit, it can now be called from anywhere.

While I was as it, I suggested some improvements (maybe a bit opinionated?), feel free to request removal of some if it doesn't suit your practices.
There are several commits to better isolate changes.
Commits detailed message contain motivation/explanation when relevant if you need.