### PR TITLE
doc: Fix markup of a clode block in Texture Healing.md

### DIFF
--- a/docs/Texture Healing.md
+++ b/docs/Texture Healing.md
@@ -143,15 +143,11 @@ A note on OpenType classes: these are sequential containers. The order of elemen
 
 Once these classes are defined, a series of lookups are defined, such as:
 
-**`lookup** defaultLeftPass {`
-
-*`#if a glyph that can take space is to the left of a glyph that can give space, cause the glyph that can give space to extend to the right`*
-
-*`#sample: im = i.left m;`*
-
-**`sub** @defaults_can_give_space' @defaults_can_take_space **by** @can_give_space_left;`
-
-`} defaultLeftPass;`
+<pre><code><b>lookup</b> defaultLeftPass {
+<i>#if a glyph that can take space is to the left of a glyph that can give space, cause the glyph that can give space to extend to the right</i>
+<i>#sample: im = i.left m;</i>
+<b>sub</b> @defaults_can_give_space' @defaults_can_take_space <b>by</b> @can_give_space_left;
+} defaultLeftPass;</code></pre>
 
 Each has been thoroughly commented to describe its purpose, using the # commenting syntax in OpenType feature code. Each contains a ‘#sample’ portion, which shows a hypothetical before/after swap in OpenType (as if the glyphs were hard-coded, when in fact the logic is class-based).
 


### PR DESCRIPTION
It looks like that markup of a code block in [Texure Healing.md](https://github.com/githubnext/monaspace/blob/3bf3e8f/docs/Texture%20Healing.md#the-opentype-feature-code) is broken below ".. are defined, such as:," like "**`lookup**`."